### PR TITLE
Udev rules update

### DIFF
--- a/51-fds-rule.rules
+++ b/51-fds-rule.rules
@@ -10,5 +10,5 @@
 # $ sudo service udev restart
 # $ sudo udevadm trigger
 #
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="00f3", MODE=="0666"
-SUBSYSTEM=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="00f3", MODE=="0666"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="00f3", MODE="0666"
+SUBSYSTEM=="usb_device", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="00f3", MODE="0666"


### PR DESCRIPTION
MODE attributes have an inappropriate assignment. They occur permission
denied error in some environments. 